### PR TITLE
Adding explicit dependency on libgcc as the build breaks depending on distribution.  Dependency on cross-compiler is implicitly added.

### DIFF
--- a/recipes-golang/golang/golang-cross.inc
+++ b/recipes-golang/golang/golang-cross.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "Go Programming Language Cross Compiler."
 HOMEPAGE = "golang.org"
-DEPENDS = "virtual/${TARGET_PREFIX}gcc"
+DEPENDS = "libgcc"
 PROVIDES = "virtual/${TARGET_PREFIX}golang"
 SRC_URI = "http://golang.org/dl/go${PV}.src.tar.gz"
 S="${WORKDIR}/go"


### PR DESCRIPTION
Resolving link issue where it is unable to find -lgcc due to dependency on libgcc missing.  And since libgcc also depends on the cross-compiler, that dependency is implicitly there.

Signed-off-by: Ahmed El-Madhoun aelmadho@cisco.com
